### PR TITLE
ユーザー画像を更新した際、同じファイル名で保存したときCDNで前回のファイルを配信してしまうので、セキュアなランダムトークンを保存時に発行…

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -56,6 +56,12 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
   def filename
-    'image' + '.png' if original_filename
+     "#{secure_token(10)}.png" if original_filename.present?
+  end
+
+  protected
+  def secure_token(length=16)
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
   end
 end


### PR DESCRIPTION
…する形式に変更