### PR TITLE
Works

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,7 +7,7 @@ class Post < ApplicationRecord
   belongs_to :user
   belongs_to :game
 
-  has_many :likes
+  has_many :likes, dependent: :destroy
   accepts_nested_attributes_for :likes
   has_many :users, through: :likes
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: 'password'
     ports:
-      - '3306:3306'
+      - '4306:3306'
     volumes:
       - mysql-data:/var/lib/mysql
   chrome:


### PR DESCRIPTION
PostモデルのLikeモデルのリレーションでdependentオプションをつけ忘れたことにより、Postが削除されたのにも関わらず、削除されたPostに対応するLikeモデルが残っていた。
それにより、人気記事表示機能で残っていたLikeモデルを参照してPostを探そうとしていた部分でnot findエラーが発生していた問題を修正。